### PR TITLE
Csrf to jwt

### DIFF
--- a/web_editor/common/testcase.py
+++ b/web_editor/common/testcase.py
@@ -2,12 +2,30 @@ from django.test import TestCase
 from user.models import User
 
 from rest_framework_simplejwt.tokens import RefreshToken
+from factory.django import DjangoModelFactory
+
+class UserFactory(DjangoModelFactory):
+    class Meta:
+       model = User
+
+    email = 'test@test.com'
+
+    @classmethod
+    def create(cls, **kwargs):
+        user = User.objects.create(**kwargs)
+        user.set_password(kwargs.get('password', ''))
+        user.save()
+        return user
 
 class TestCaseBase(TestCase):
-    @property
-    def bearer_token(self):
-        # assuming there is a user in User model
-        user = User.objects.get(id=1)
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(
+            user_id='foo',
+            username='foo_test',
+            email='foo@test.com',
+            password='fooPassword',
+        )
 
-        refresh = RefreshToken.for_user(user)
-        return {"HTTP_AUTHORIZATION":f'Bearer {refresh.access_token}'}
+        refresh = RefreshToken.for_user(cls.user)
+        cls.bearer_token = {"HTTP_AUTHORIZATION":f'Bearer {refresh.access_token}'}

--- a/web_editor/common/testcase.py
+++ b/web_editor/common/testcase.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+from user.models import User
+
+from rest_framework_simplejwt.tokens import RefreshToken
+
+class TestCaseBase(TestCase):
+    @property
+    def bearer_token(self):
+        # assuming there is a user in User model
+        user = User.objects.get(id=1)
+
+        refresh = RefreshToken.for_user(user)
+        return {"HTTP_AUTHORIZATION":f'Bearer {refresh.access_token}'}

--- a/web_editor/common/testcase.py
+++ b/web_editor/common/testcase.py
@@ -3,6 +3,7 @@ from user.models import User
 
 from rest_framework_simplejwt.tokens import RefreshToken
 from factory.django import DjangoModelFactory
+from freezegun import freeze_time
 
 class UserFactory(DjangoModelFactory):
     class Meta:
@@ -26,6 +27,8 @@ class TestCaseBase(TestCase):
             email='foo@test.com',
             password='fooPassword',
         )
-
+        
+        freezer = freeze_time("2022-02-22 00:00:00")
+        freezer.start()
         refresh = RefreshToken.for_user(cls.user)
         cls.bearer_token = {"HTTP_AUTHORIZATION":f'Bearer {refresh.access_token}'}

--- a/web_editor/project/tests.py
+++ b/web_editor/project/tests.py
@@ -55,7 +55,7 @@ class PostProjectTestCase(TestCaseBase):
             "title" : "title2"
         }
         response = self.client.post("/api/v1/project/", data, **self.bearer_token)
-        print(response)
+        print(response.json())
         self.assertEqual(response.json()["writer"]["username"], "foo_test")
         self.assertEqual(response.json()["title"], "title2")
         self.assertEqual(Project.objects.count(), 2)
@@ -142,7 +142,7 @@ class PutProjectTestCase(TestCaseBase):
         id = self.project.id # Project.objects.get(title="title1").id
         data = {"title" : "title2"}
         response = self.client.put("/api/v1/project/" + str(id) + "/", data, content_type="application/json", **self.bearer_token)
-        print(response)
+        print(response.json())
         self.assertEqual(response.json()["title"], "title2")
         
     def test_update_project_updated_at(self):

--- a/web_editor/project/tests.py
+++ b/web_editor/project/tests.py
@@ -55,6 +55,7 @@ class PostProjectTestCase(TestCaseBase):
             "title" : "title2"
         }
         response = self.client.post("/api/v1/project/", data, **self.bearer_token)
+        print(response)
         self.assertEqual(response.json()["writer"]["username"], "foo_test")
         self.assertEqual(response.json()["title"], "title2")
         self.assertEqual(Project.objects.count(), 2)
@@ -141,6 +142,7 @@ class PutProjectTestCase(TestCaseBase):
         id = self.project.id # Project.objects.get(title="title1").id
         data = {"title" : "title2"}
         response = self.client.put("/api/v1/project/" + str(id) + "/", data, content_type="application/json", **self.bearer_token)
+        print(response)
         self.assertEqual(response.json()["title"], "title2")
         
     def test_update_project_updated_at(self):

--- a/web_editor/project/tests.py
+++ b/web_editor/project/tests.py
@@ -5,6 +5,9 @@ from freezegun import freeze_time
 from user.tests import UserFactory
 from user.models import User
 import datetime
+from common.testcase import TestCaseBase
+from rest_framework_simplejwt.tokens import RefreshToken
+
 class ProjectFactory(DjangoModelFactory):
     model = Project
     
@@ -13,15 +16,10 @@ class ProjectFactory(DjangoModelFactory):
         project = Project.objects.create(**validated_data)
         return project
     
-class PostProjectTestCase(TestCase):
+class PostProjectTestCase(TestCaseBase):
     @classmethod
     def setUpTestData(cls):
-        cls.user = UserFactory(
-            user_id='foo',
-            username='foo_test',
-            email='foo@test.com',
-            password='fooPassword',
-        )
+        super().setUpTestData()
         cls.data = {
             "title" : "title1",
             "writer" : cls.user
@@ -29,7 +27,6 @@ class PostProjectTestCase(TestCase):
         cls.project = ProjectFactory(**cls.data)
 
     def setUp(self):
-        self.client.login(user_id='foo', password='fooPassword')
         self.freezer = freeze_time("2022-02-22 00:00:00")
         self.freezer.start()
         
@@ -41,7 +38,7 @@ class PostProjectTestCase(TestCase):
         data = {
             "writer" : user
         }
-        response = self.client.post("/api/v1/project/", data)
+        response = self.client.post("/api/v1/project/", data, **self.bearer_token)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(Project.objects.count(), 1)
         
@@ -49,7 +46,7 @@ class PostProjectTestCase(TestCase):
         data = {
             "title" : "no writer"
         }
-        response = self.client.post("/api/v1/project/", data)
+        response = self.client.post("/api/v1/project/", data, **self.bearer_token)
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Project.objects.count(), 2)
         
@@ -58,7 +55,7 @@ class PostProjectTestCase(TestCase):
             "title" : "title2",
             "writer" : self.user
         }
-        response = self.client.post("/api/v1/project/", data)
+        response = self.client.post("/api/v1/project/", data, **self.bearer_token)
         self.assertEqual(response.json()['writer']['username'], "foo_test")
         self.assertEqual(response.json()['title'], "title2")
         self.assertEqual(Project.objects.count(), 2)
@@ -68,19 +65,14 @@ class PostProjectTestCase(TestCase):
             "title" : "title2",
             "writer" : self.user
         }
-        self.client.post("/api/v1/project/", data)
+        self.client.post("/api/v1/project/", data, **self.bearer_token)
         project = Project.objects.get(title="title2")
         self.assertEqual(project.created_at, datetime.datetime.strptime("2022-02-22 00:00:00", '%Y-%m-%d %H:%M:%S').replace(tzinfo=datetime.timezone.utc))
     
-class GetProjectTestCase(TestCase):
+class GetProjectTestCase(TestCaseBase):
     @classmethod
     def setUpTestData(cls):
-        cls.user = UserFactory(
-            user_id='foo',
-            username='foo_test',
-            email='foo@test.com',
-            password='fooPassword',
-        )
+        super().setUpTestData()
         cls.data1 = {
             "title" : "title1",
             "writer" : cls.user
@@ -99,44 +91,41 @@ class GetProjectTestCase(TestCase):
         )
         
     def setUp(self):
-        self.client.login(user_id='foo', password='fooPassword')
+        pass
         
     def test_get_single_project(self):
         data = self.data1.copy()
         data.update({"title" : "title3"})
-        post_response = self.client.post("/api/v1/project/", data)
+        post_response = self.client.post("/api/v1/project/", data, **self.bearer_token)
         pk = post_response.json()['id']
-        response = self.client.get("/api/v1/project/" + str(pk) + "/")
+        response = self.client.get("/api/v1/project/" + str(pk) + "/", **self.bearer_token)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()[0]["title"], "title3")
         
     def test_get_my_project(self):
-        response = self.client.get("/api/v1/project/me/")
+        response = self.client.get("/api/v1/project/me/", **self.bearer_token)
         self.assertEqual(len(response.json()), 2)
         
     def test_get_my_project_none(self):
-        self.client.login(user_id='foo2', password='fooPassword')
-        response = self.client.get("/api/v1/project/me/")
+        refresh = RefreshToken.for_user(self.wrong_user)
+        wrong_user_bearer_token = {"HTTP_AUTHORIZATION":f'Bearer {refresh.access_token}'}
+
+        response = self.client.get("/api/v1/project/me/", **wrong_user_bearer_token)
         self.assertEqual(len(response.json()), 0)
 
     def test_get_project_list(self):
-        response = self.client.get("/api/v1/project/")
+        response = self.client.get("/api/v1/project/", **self.bearer_token)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()), 2)
         
     def test_get_wrong_project(self):
-        response = self.client.get("/api/v1/project/0/")
+        response = self.client.get("/api/v1/project/0/", **self.bearer_token)
         self.assertEqual(response.status_code, 400)
         
-class PutProjectTestCase(TestCase):
+class PutProjectTestCase(TestCaseBase):
     @classmethod
     def setUpTestData(cls):
-        cls.user = UserFactory(
-            user_id='foo',
-            username='foo_test',
-            email='foo@test.com',
-            password='fooPassword',
-        )
+        super().setUpTestData()
         cls.data = {
             "title" : "title1",
             "writer" : cls.user
@@ -144,7 +133,6 @@ class PutProjectTestCase(TestCase):
         cls.project = ProjectFactory(**cls.data)
         
     def setUp(self):
-        self.client.login(user_id='foo', password='fooPassword')
         self.freezer = freeze_time("2022-02-22 00:00:00")
         self.freezer.start()
         
@@ -154,27 +142,27 @@ class PutProjectTestCase(TestCase):
     def test_update_project_title(self):
         id = Project.objects.get(title="title1").id
         data = {"title" : "title2"}
-        response = self.client.put("/api/v1/project/" + str(id) + "/", data, content_type="application/json")
+        response = self.client.put("/api/v1/project/" + str(id) + "/", data, content_type="application/json", **self.bearer_token)
         self.assertEqual(response.json()["title"], "title2")
         
     def test_update_project_updated_at(self):
         id = Project.objects.get(title="title1").id
         data = {"title" : "title2"}
-        self.client.put("/api/v1/project/" + str(id) + "/", data, content_type="application/json")
+        self.client.put("/api/v1/project/" + str(id) + "/", data, content_type="application/json", **self.bearer_token)
         project = Project.objects.get(title="title2")
 
         self.assertEqual(project.updated_at, datetime.datetime.strptime("2022-02-22 00:00:00", '%Y-%m-%d %H:%M:%S').replace(tzinfo=datetime.timezone.utc))
         
     def test_update_nothing(self):
         id = Project.objects.get(title="title1").id
-        self.client.put("/api/v1/project/" + str(id) + "/", {}, content_type="application/json")
+        self.client.put("/api/v1/project/" + str(id) + "/", {}, content_type="application/json", **self.bearer_token)
         project = Project.objects.get(title="title1")
 
         self.assertEqual(project.title, "title1")
         self.assertEqual(project.updated_at, datetime.datetime.strptime("2022-02-22 00:00:00", '%Y-%m-%d %H:%M:%S').replace(tzinfo=datetime.timezone.utc))
         
     def test_update_wrong_project(self):
-        response = self.client.put("/api/v1/project/0/")
+        response = self.client.put("/api/v1/project/0/", **self.bearer_token)
         self.assertEqual(response.status_code, 400)
         
     def test_update_project_writer(self):
@@ -185,20 +173,15 @@ class PutProjectTestCase(TestCase):
             email='foo2@test.com',
             password='fooPassword',
         )
-        self.client.put("/api/v1/project/" + str(id) + "/", {"writer" : wrong_user.id}, content_type="application/json")
+        self.client.put("/api/v1/project/" + str(id) + "/", {"writer" : wrong_user.id}, content_type="application/json", **self.bearer_token)
         project = Project.objects.get(title="title1")
         self.assertNotEqual(project.writer, wrong_user)
         self.assertEqual(project.writer, self.user)        
         
-class DeleteProjectTestCase(TestCase):
+class DeleteProjectTestCase(TestCaseBase):
     @classmethod
     def setUpTestData(cls):
-        cls.user = UserFactory(
-            user_id='foo',
-            username='foo_test',
-            email='foo@test.com',
-            password='fooPassword',
-        )
+        super().setUpTestData()
         cls.data = {
             "title" : "title1",
             "writer" : cls.user
@@ -209,16 +192,16 @@ class DeleteProjectTestCase(TestCase):
         ProjectFactory(**data)
         
     def setUp(self):
-        self.client.login(user_id='foo', password='fooPassword')
+        pass
         
     def test_delete_project(self):
         project = Project.objects.get(title="title2")
-        response = self.client.delete("/api/v1/project/" + str(project.id) + "/")
+        response = self.client.delete("/api/v1/project/" + str(project.id) + "/", **self.bearer_token)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.json()['success'])
-        response = self.client.get("/api/v1/project/" + str(project.id) + "/")
+        response = self.client.get("/api/v1/project/" + str(project.id) + "/", **self.bearer_token)
         self.assertEqual(response.status_code, 400)
         
     def test_delete_wrong_project(self):
-        response = self.client.delete("/api/v1/project/0/")
+        response = self.client.delete("/api/v1/project/0/", **self.bearer_token)
         self.assertEqual(response.status_code, 400)

--- a/web_editor/project/tests.py
+++ b/web_editor/project/tests.py
@@ -34,9 +34,9 @@ class PostProjectTestCase(TestCaseBase):
         self.freezer.stop()
         
     def test_post_no_title(self):
-        user = User.objects.get(user_id="foo")
+        #user = User.objects.get(user_id="foo")
         data = {
-            "writer" : user
+            "writer" : self.user
         }
         response = self.client.post("/api/v1/project/", data, **self.bearer_token)
         self.assertEqual(response.status_code, 400)
@@ -52,18 +52,16 @@ class PostProjectTestCase(TestCaseBase):
         
     def test_post_project(self):
         data = {
-            "title" : "title2",
-            "writer" : self.user
+            "title" : "title2"
         }
         response = self.client.post("/api/v1/project/", data, **self.bearer_token)
-        self.assertEqual(response.json()['writer']['username'], "foo_test")
-        self.assertEqual(response.json()['title'], "title2")
+        self.assertEqual(response.json()["writer"]["username"], "foo_test")
+        self.assertEqual(response.json()["title"], "title2")
         self.assertEqual(Project.objects.count(), 2)
         
     def test_post_project_created_at(self):
         data = {
-            "title" : "title2",
-            "writer" : self.user
+            "title" : "title2"
         }
         self.client.post("/api/v1/project/", data, **self.bearer_token)
         project = Project.objects.get(title="title2")
@@ -140,13 +138,13 @@ class PutProjectTestCase(TestCaseBase):
         self.freezer.stop()
         
     def test_update_project_title(self):
-        id = Project.objects.get(title="title1").id
+        id = self.project.id # Project.objects.get(title="title1").id
         data = {"title" : "title2"}
         response = self.client.put("/api/v1/project/" + str(id) + "/", data, content_type="application/json", **self.bearer_token)
         self.assertEqual(response.json()["title"], "title2")
         
     def test_update_project_updated_at(self):
-        id = Project.objects.get(title="title1").id
+        id = self.project.id # Project.objects.get(title="title1").id
         data = {"title" : "title2"}
         self.client.put("/api/v1/project/" + str(id) + "/", data, content_type="application/json", **self.bearer_token)
         project = Project.objects.get(title="title2")
@@ -154,7 +152,7 @@ class PutProjectTestCase(TestCaseBase):
         self.assertEqual(project.updated_at, datetime.datetime.strptime("2022-02-22 00:00:00", '%Y-%m-%d %H:%M:%S').replace(tzinfo=datetime.timezone.utc))
         
     def test_update_nothing(self):
-        id = Project.objects.get(title="title1").id
+        id = self.project.id #Project.objects.get(title="title1").id
         self.client.put("/api/v1/project/" + str(id) + "/", {}, content_type="application/json", **self.bearer_token)
         project = Project.objects.get(title="title1")
 
@@ -166,7 +164,7 @@ class PutProjectTestCase(TestCaseBase):
         self.assertEqual(response.status_code, 400)
         
     def test_update_project_writer(self):
-        id = Project.objects.get(title="title1").id
+        id = self.project.id #Project.objects.get(title="title1").id
         wrong_user = UserFactory(
             user_id='foo2',
             username='foo2_test',

--- a/web_editor/project/tests.py
+++ b/web_editor/project/tests.py
@@ -55,7 +55,6 @@ class PostProjectTestCase(TestCaseBase):
             "title" : "title2"
         }
         response = self.client.post("/api/v1/project/", data, **self.bearer_token)
-        print(response.json())
         self.assertEqual(response.json()["writer"]["username"], "foo_test")
         self.assertEqual(response.json()["title"], "title2")
         self.assertEqual(Project.objects.count(), 2)
@@ -142,7 +141,6 @@ class PutProjectTestCase(TestCaseBase):
         id = self.project.id # Project.objects.get(title="title1").id
         data = {"title" : "title2"}
         response = self.client.put("/api/v1/project/" + str(id) + "/", data, content_type="application/json", **self.bearer_token)
-        print(response.json())
         self.assertEqual(response.json()["title"], "title2")
         
     def test_update_project_updated_at(self):

--- a/web_editor/user/serializer.py
+++ b/web_editor/user/serializer.py
@@ -55,12 +55,11 @@ class JWTRefreshSerializer(serializers.Serializer):
 
         data = {"access_token": str(refresh_token.access_token)}
 
-        if settings.ROTATE_REFRESH_TOKENS:
-            refresh_token.set_jti()
-            refresh_token.set_exp()
-            refresh_token.set_iat()
+        refresh_token.set_jti()
+        refresh_token.set_exp()
+        refresh_token.set_iat()
 
-            data["refresh_token"] = str(refresh_token)
-            data["access_token"] = str(refresh_token.access_token)
+        data["refresh_token"] = str(refresh_token)
+        data["access_token"] = str(refresh_token.access_token)
 
         return data

--- a/web_editor/user/tests.py
+++ b/web_editor/user/tests.py
@@ -6,7 +6,7 @@ from passlib.handlers.django import django_pbkdf2_sha256
 from rest_framework import status
 
 from user.models import User
-
+from common.testcase import TestCaseBase
 
 class UserFactory(DjangoModelFactory):
     class Meta:
@@ -118,7 +118,7 @@ class PostUserTestCase(TestCase):
         self.assertEqual(User.objects.count(), 2)
 
 
-class GetUserTestCase(TestCase):
+class GetUserTestCase(TestCaseBase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory(
@@ -133,8 +133,8 @@ class GetUserTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_get_user_error_not_found(self):
-        self.client.login(user_id='foo', password='fooPassword')
-        response = self.client.get('/api/v1/users/100/')
+        #self.client.login(user_id='foo', password='fooPassword')
+        response = self.client.get('/api/v1/users/100/', **self.bearer_token)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_user(self):
@@ -145,9 +145,9 @@ class GetUserTestCase(TestCase):
             'password': 'barPassword',
         })
         self.assertEqual(User.objects.count(), 2)
-        self.client.login(user_id='foo', password='fooPassword')
+        #self.client.login(user_id='foo', password='fooPassword')
         user = User.objects.get(user_id='bar')
-        response = self.client.get('/api/v1/users/' + str(user.pk) + '/')
+        response = self.client.get('/api/v1/users/' + str(user.pk) + '/', **self.bearer_token)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         self.assertEqual(data['user_id'], 'bar')
@@ -155,8 +155,8 @@ class GetUserTestCase(TestCase):
         self.assertEqual(data['email'], 'bar@test.com')
 
     def test_get_me(self):
-        self.client.login(user_id='foo', password='fooPassword')
-        response = self.client.get('/api/v1/users/me/')
+        #self.client.login(user_id='foo', password='fooPassword')
+        response = self.client.get('/api/v1/users/me/', **self.bearer_token)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         self.assertEqual(data['user_id'], 'foo')
@@ -164,7 +164,7 @@ class GetUserTestCase(TestCase):
         self.assertEqual(data['email'], 'foo@test.com')
 
 
-class PutUserTestCase(TestCase):
+class PutUserTestCase(TestCaseBase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory(
@@ -179,8 +179,8 @@ class PutUserTestCase(TestCase):
         }
 
     def test_put_user_error(self):
-        self.client.login(user_id='foo', password='fooPassword')
-        response = self.client.put('/api/v1/users/100/', data=self.put_data)
+        #self.client.login(user_id='foo', password='fooPassword')
+        response = self.client.put('/api/v1/users/100/', data=self.put_data, **self.bearer_token)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_put_me_error_duplicate_email(self):
@@ -191,40 +191,40 @@ class PutUserTestCase(TestCase):
             'password': 'barPassword',
         })
         self.assertEqual(User.objects.count(), 2)
-        self.client.login(user_id='foo', password='fooPassword')
+        #self.client.login(user_id='foo', password='fooPassword')
         data = self.put_data.copy()
         data.update({'email': 'bar@test.com'})
-        response = self.client.put('/api/v1/users/me/', data=data, content_type='application/json')
+        response = self.client.put('/api/v1/users/me/', data=data, content_type='application/json', **self.bearer_token)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_put_me_error_bad_request(self):
-        self.client.login(user_id='foo', password='fooPassword')
+        #self.client.login(user_id='foo', password='fooPassword')
         # Try to change User ID
         data = self.put_data.copy()
         data['user_id'] = 'bad_user_id'
-        response = self.client.put('/api/v1/users/me/', data=data, content_type='application/json')
+        response = self.client.put('/api/v1/users/me/', data=data, content_type='application/json', **self.bearer_token)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         # Invalid Username
         data = self.put_data.copy()
         data.update({'username': 'very_very_long_username'})
-        response = self.client.put('/api/v1/users/me/', data=data, content_type='application/json')
+        response = self.client.put('/api/v1/users/me/', data=data, content_type='application/json', **self.bearer_token)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         # Invalid Email
         data = self.put_data.copy()
         data.update({'email': 'bad_email'})
-        response = self.client.put('/api/v1/users/me/', data=data, content_type='application/json')
+        response = self.client.put('/api/v1/users/me/', data=data, content_type='application/json', **self.bearer_token)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         data = self.put_data.copy()
         data.update({'email': 'super_' * 15 + 'long_email@test.com'})
-        response = self.client.put('/api/v1/users/me/', data=data, content_type='application/json')
+        response = self.client.put('/api/v1/users/me/', data=data, content_type='application/json', **self.bearer_token)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_put_me(self):
-        self.client.login(user_id='foo', password='fooPassword')
-        response = self.client.put('/api/v1/users/me/', data=self.put_data, content_type='application/json')
+        #self.client.login(user_id='foo', password='fooPassword')
+        response = self.client.put('/api/v1/users/me/', data=self.put_data, content_type='application/json', **self.bearer_token)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         self.assertEqual(data['user_id'], 'foo')
@@ -232,7 +232,7 @@ class PutUserTestCase(TestCase):
         self.assertEqual(data['email'], 'foo_put_test@test.com')
 
 
-class DeleteUserTestCase(TestCase):
+class DeleteUserTestCase(TestCaseBase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory(
@@ -243,13 +243,13 @@ class DeleteUserTestCase(TestCase):
         )
 
     def test_delete_user_error(self):
-        self.client.login(user_id='foo', password='fooPassword')
-        response = self.client.delete('/api/v1/users/100/')
+        #self.client.login(user_id='foo', password='fooPassword')
+        response = self.client.delete('/api/v1/users/100/', **self.bearer_token)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_delete_me(self):
-        self.client.login(user_id='foo', password='fooPassword')
-        response = self.client.delete('/api/v1/users/me/')
+        #self.client.login(user_id='foo', password='fooPassword')
+        response = self.client.delete('/api/v1/users/me/', **self.bearer_token)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(User.objects.get(user_id='foo').is_active)
         self.assertFalse(self.client.login(user_id='foo', password='fooPassword'))

--- a/web_editor/user/urls.py
+++ b/web_editor/user/urls.py
@@ -10,6 +10,6 @@ urlpatterns = [
     path('', include(router.urls)),
     path('signup/', UserSignUpView.as_view()),
     path('login/', UserLoginView.as_view()),
-    path('refresh/', TokenRefreshView.as_view()),
+    path('refresh/', JWTRefreshView.as_view()),
     #path('verify/', CSRFCheckView.as_view())
 ]

--- a/web_editor/user/views.py
+++ b/web_editor/user/views.py
@@ -79,6 +79,19 @@ class UserLoginView(APIView):
 
         return Response(status=status.HTTP_403_FORBIDDEN, data="아이디나 패스워드가 일치하지 않습니다.")
 
+class JWTRefreshView(APIView):
+    permission_classes = (permissions.AllowAny, )
+
+    def post(self, request, *args, **kwargs):
+        data = JWTRefreshSerializer.validate(request.data)
+        response = Response(
+            data=data,
+            status=status.HTTP_200_OK,
+        )
+
+        response.set_cookie("refresh_token", data["refresh_token"], httponly=True)
+
+        return response
 
 class CSRFCheckView(View):
     

--- a/web_editor/user/views.py
+++ b/web_editor/user/views.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import GenericViewSet
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+from  rest_framework_simplejwt.exceptions import TokenError
 import json
 
 from .serializer import *
@@ -83,15 +84,20 @@ class JWTRefreshView(APIView):
     permission_classes = (permissions.AllowAny, )
 
     def post(self, request, *args, **kwargs):
-        data = JWTRefreshSerializer.validate(request.data)
-        response = Response(
-            data=data,
-            status=status.HTTP_200_OK,
-        )
+        serializer = JWTRefreshSerializer(data=request.data)
 
-        response.set_cookie("refresh_token", data["refresh_token"], httponly=True)
+        try:
+            serializer.is_valid(raise_exception=True)
+            data = serializer.validated_data
+            response = Response(
+                data=data,
+                status=status.HTTP_200_OK,
+            )
+            response.set_cookie("refresh_token", data["refresh_token"], httponly=True)
+            return response
 
-        return response
+        except TokenError as e:
+            return Response(status=status.HTTP_401_UNAUTHORIZED, data="Token is invalid or expired")
 
 class CSRFCheckView(View):
     

--- a/web_editor/web_editor/settings.py
+++ b/web_editor/web_editor/settings.py
@@ -192,7 +192,7 @@ REST_USE_JWT = True
 SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(minutes=20),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
-    'ROTATE_REFRESH_TOKENS': False,
+    'ROTATE_REFRESH_TOKENS': True,
     'BLACKLIST_AFTER_ROTATION': False,
     'UPDATE_LAST_LOGIN': False,
 


### PR DESCRIPTION
- jwt 활용한 유저 인증으로 테스트 코드 변경
- token refresh api: 새로운 refresh_token도 반환하도록 변경 & response에서 key를 "access" -> "access_token"으로 변경